### PR TITLE
Readme and dotenv ap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ application.yml
 
 # Ignore application configuration
 /config/application.yml
+
+# Used by dotenv library to load environment variables.
+*.env

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ gem 'sinatra-activerecord'
 
 gem 'rspec'
 
+gem 'dotenv'
+
 group :test do
   gem 'rack-test'
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
+    dotenv (2.7.5)
     faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
     hashdiff (1.0.0)
@@ -104,6 +105,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord
+  dotenv
   faraday
   figaro!
   pg

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+Code Songs Microservice
+
+Database Setup
+Local Environment:
+  - `bundle exec rake db:create`
+  - `bundle exec rake db:migrate`
+  - `bundle exec rake db:seed`
+Test Environment:
+  - `RACK_ENV=test bundle exec rake db:{migrate,seed}`
+
+Run Tests:
+  - `bundle exec rspec`
+
+Using DOTENV in development and testing:
+Keep enviornment variables secure by saving a `.env` file in the root directory. See more information about using dotenv gem at https://github.com/bkeepers/dotenv

--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,6 @@
 require 'sinatra'
 require 'sinatra/activerecord'
+require 'dotenv/load'
 
 Dir["#{File.dirname(__FILE__)}/app/**/*.rb"].each { |f| load(f) }
 
@@ -11,4 +12,3 @@ get '/tracks' do
   @tracks = Track.all
   @tracks.first.title
 end
-


### PR DESCRIPTION
Adding the dotenv gem to setup with corresponding requirement in the app.rb

Also added a Readme with database setup instructions for development and testing and a note on using dotenv.

Hoping this also works with an environment setup with just figaro and it doesn't error out without a `.env` file.