### PR TITLE
Add youtube artist name sanitizer

### DIFF
--- a/app/services/you_tube_service.rb
+++ b/app/services/you_tube_service.rb
@@ -5,7 +5,7 @@ class YouTubeService
 
   def initialize(song_title, artist_name)
     @song_title = song_title
-    @artist_name = artist_name
+    @artist_name = name_sanatazier(artist_name)
   end
 
   def get_youtube_link
@@ -28,7 +28,19 @@ class YouTubeService
     "https://www.youtube.com/embed/#{video_id}"
   end
 
+  def name_sanatazier(name)
+    encoding_options = {
+      :invalid           => :replace,  # Replace invalid byte sequences
+      :undef             => :replace,  # Replace anything not defined in ASCII
+      :replace           => '',        # Use a blank for those replacements
+      :universal_newline => true       # Always break lines with \n
+    }
+
+    name.encode(Encoding.find('ASCII'), encoding_options)
+  end
+  
   private
   attr_reader :song_title, :artist_name
+
 
 end

--- a/app/services/you_tube_service.rb
+++ b/app/services/you_tube_service.rb
@@ -5,7 +5,7 @@ class YouTubeService
 
   def initialize(song_title, artist_name)
     @song_title = song_title
-    @artist_name = name_sanatazier(artist_name)
+    @artist_name = name_sanitizer(artist_name)
   end
 
   def get_youtube_link
@@ -28,7 +28,7 @@ class YouTubeService
     "https://www.youtube.com/embed/#{video_id}"
   end
 
-  def name_sanatazier(name)
+  def name_sanitizer(name)
     encoding_options = {
       :invalid           => :replace,  # Replace invalid byte sequences
       :undef             => :replace,  # Replace anything not defined in ASCII
@@ -38,7 +38,7 @@ class YouTubeService
 
     name.encode(Encoding.find('ASCII'), encoding_options)
   end
-  
+
   private
   attr_reader :song_title, :artist_name
 

--- a/spec/services/you_tube_service_spec.rb
+++ b/spec/services/you_tube_service_spec.rb
@@ -11,4 +11,13 @@ describe YouTubeService do
     expect(youtube_service.get_youtube_link).to be_a String
     expect(youtube_service.get_youtube_link).to eq("https://www.youtube.com/embed/DtVBCG6ThDk")
   end
+
+  it 'sanitizes the name of an artist that uses non ASCII characters', :vcr do
+
+    song_title = 'White Christmas'
+    artist_name = 'Michael Bublé'
+    youtube_service = YouTubeService.new(song_title, artist_name)
+
+    expect(youtube_service.name_sanatazier(artist_name)).to eq("Michael Bubl")
+  end
 end

--- a/spec/services/you_tube_service_spec.rb
+++ b/spec/services/you_tube_service_spec.rb
@@ -18,6 +18,6 @@ describe YouTubeService do
     artist_name = 'Michael Bublé'
     youtube_service = YouTubeService.new(song_title, artist_name)
 
-    expect(youtube_service.name_sanatazier(artist_name)).to eq("Michael Bubl")
+    expect(youtube_service.name_sanitizer(artist_name)).to eq("Michael Bubl")
   end
 end


### PR DESCRIPTION
Add a sanitizer to the youtube service that removes any non-ascii characters from the artist name. It just removes the character which might skew our youtube video results but I think this should fix the non-ascii issues.

I also added a test to check for it.