### PR TITLE
Reformat output to be a hash with key songs with value array of songs

### DIFF
--- a/app/poros/tracks_builder.rb
+++ b/app/poros/tracks_builder.rb
@@ -1,9 +1,10 @@
 class TracksBuilder
 
   def self.build_collection(tracks)
-    as_array = tracks.map do |track|
-      {title: track.title, link: track.youtube_link}
+    songs = {songs: []}
+    tracks.each do |track|
+      songs[:songs].push({title: track.title, link: track.youtube_link})
     end
-    as_array.to_json
+    songs.to_json
   end
 end

--- a/spec/app/codesongs_matcher_spec.rb
+++ b/spec/app/codesongs_matcher_spec.rb
@@ -8,8 +8,7 @@ describe "when the endpoint '/codesongs_matcher' is hit" do
 
     expect(last_response).to be_ok
     # expect(last_response.body).to be_a JSON
-
-    expected_output = "[{\"title\":\"Shape of You\",\"link\":\"https://www.youtube.com/embed/JGwWNGJdvx8\"},{\"title\":\"Thinking Out Loud\",\"link\":\"https://www.youtube.com/embed/lp-EO5I60KA\"},{\"title\":\"Photograph\",\"link\":\"https://www.youtube.com/embed/qgmXPCX4VzU\"},{\"title\":\"Perfect\",\"link\":\"https://www.youtube.com/embed/UDDMYw_IZnE\"},{\"title\":\"South of the Border\",\"link\":\"https://www.youtube.com/embed/UPOT2tgY9QQ\"}]"
+    expected_output = "{\"songs\":[{\"title\":\"Shape of You\",\"link\":\"https://www.youtube.com/embed/JGwWNGJdvx8\"},{\"title\":\"Thinking Out Loud\",\"link\":\"https://www.youtube.com/embed/lp-EO5I60KA\"},{\"title\":\"Photograph\",\"link\":\"https://www.youtube.com/embed/qgmXPCX4VzU\"},{\"title\":\"Perfect\",\"link\":\"https://www.youtube.com/embed/UDDMYw_IZnE\"},{\"title\":\"South of the Border\",\"link\":\"https://www.youtube.com/embed/UPOT2tgY9QQ\"}]}"
     expect(last_response.body).to eq expected_output
   end
 

--- a/spec/poros/tracks_builder_spec.rb
+++ b/spec/poros/tracks_builder_spec.rb
@@ -6,10 +6,10 @@ describe TracksBuilder do
 
     t2 = Track.create(title: 'Umbrella', mm_track_id: 32130011, mm_artist_id: 33491890, artist_name: 'Rhianna', youtube_link: 'umbrella_link')
 
-    expected_output = [
+    expected_output = {songs: [
       {title: "Rocket Man (I Think It's Going to Be a Long, Long Time)", link: 'rocket_man_link' },
       {title: "Umbrella", link: 'umbrella_link' },
-    ].to_json
+    ]}.to_json
     expect(TracksBuilder.build_collection([t1, t2])).to eq expected_output
   end
 end


### PR DESCRIPTION
Ran into travis-ci issues on the front end for trying to read an array of json as json, looks like default is a hash.

all tests passing